### PR TITLE
Ensure binary is statically linked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           GOOS: linux
           GOARCH: amd64
+          CGO_ENABLED: 0
         run: |
           go build -o lku-${{ github.ref_name }}_linux_amd64
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] You have read the contributing guide
- [x] Tests for the changes have been added
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

The user is presented with an error when using distros with an older libc version.

Issue Number: Fixes #4 

## What is the new behavior?

- The binary is now built as a statically linked binary (instead of dynamically linked)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

**If yes, please describe...**

## Other relevant information
 N/A