### PR TITLE
Add a secret_collection class with get/set/unlock

### DIFF
--- a/pkg/secret_collection/secret_collection.go
+++ b/pkg/secret_collection/secret_collection.go
@@ -1,0 +1,70 @@
+package secret_collection
+
+import (
+	"fmt"
+
+	secrets "github.com/Keeper-Security/linux-keyring-utility/pkg/dbus_secrets"
+	dbus "github.com/godbus/dbus/v5"
+)
+
+type SecretCollection struct {
+	Conn    *dbus.Conn
+	Session dbus.ObjectPath
+	Path    dbus.ObjectPath
+}
+
+func Collection(name string) (*SecretCollection, error) {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to connect to the D-Bus Session Bus: %v", err)
+	}
+	session, err := secrets.Open(conn)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to open a D-Bus session: %v", err)
+	}
+	if name != "" && name != "default" {
+		return &SecretCollection{conn, session, secrets.NamedCollection(conn, name)}, nil
+	} else {
+		return &SecretCollection{conn, session, secrets.DefaultCollection(conn)}, nil
+	}
+}
+
+func DefaultCollection() (*SecretCollection, error) {
+	return Collection("default")
+}
+
+func (sc *SecretCollection) Get(applicationName, label string) ([]byte, error) {
+	if secret, err := secrets.GetItem(sc.Conn, sc.Path, sc.Session, applicationName, label); err == nil {
+		return secret.Value, nil
+	} else {
+		return nil, fmt.Errorf("Unable to retrieve the secret '%s' for application '%s' from collection '%s': %s: %v", label, applicationName, sc.Path, label, err)
+	}
+}
+
+func (sc *SecretCollection) Set(applicationName, label string, data []byte) error {
+	if _, err := secrets.CreateItem(sc.Conn, sc.Path, applicationName, label, secrets.Secret(sc.Session, data)); err != nil {
+		return fmt.Errorf("Unable to create a secret in collection '%s' for application '%s' with label '%s': %v", sc.Path, applicationName, label, err)
+	}
+	return nil
+}
+
+func (sc *SecretCollection) Unlock() error {
+	errorf := func(err error) error {
+		return fmt.Errorf("Unable to unlock collection '%s': %v", sc.Path, err)
+	}
+
+	if unlocked, err := secrets.Unlock(sc.Conn, []dbus.ObjectPath{sc.Path}); err == nil {
+		for _, secret := range unlocked {
+			if secret == sc.Path {
+				return nil
+			}
+		}
+		if len(unlocked) > 0 {
+			return errorf(fmt.Errorf("unlocked %d collections not including it", len(unlocked)))
+		} else {
+			return errorf(fmt.Errorf("no collections were unlocked"))
+		}
+	} else {
+		return errorf(err)
+	}
+}

--- a/pkg/secret_collection/secret_collection_test.go
+++ b/pkg/secret_collection/secret_collection_test.go
@@ -1,0 +1,87 @@
+package secret_collection
+
+import (
+	"testing"
+)
+
+const (
+	testApplication = "test-app"
+	testCollection  = "kdewallet"
+	testData        = "ewogICJ1c2VybmFtZSI6ICJteV91c2VybmFtZSIsCiAgInBhc3N3b3JkIjogIm15X3Bhc3N3b3JkIgp9Cg=="
+	testLabel       = "test-label"
+)
+
+// TestNamedCollection tests the NamedCollection function.
+func TestNamedCollection(t *testing.T) {
+	collection, _ := Collection(testCollection)
+	if collection == nil {
+		t.Fatalf("Expected a valid SecretCollection, got nil")
+	}
+	if collection.Conn == nil {
+		t.Fatalf("Expected a valid dbus.Conn, got nil")
+	}
+	if collection.Session == "" {
+		t.Fatalf("Expected a valid dbus.ObjectPath for session, got empty")
+	}
+	if collection.Path == "" {
+		t.Fatalf("Expected a valid dbus.ObjectPath for path, got empty")
+	}
+}
+
+// TestDefaultCollection tests the DefaultCollection function.
+func TestDefaultCollection(t *testing.T) {
+	collection, _ := DefaultCollection()
+	if collection == nil {
+		t.Fatalf("Expected a valid SecretCollection, got nil")
+	}
+	if collection.Conn == nil {
+		t.Fatalf("Expected a valid dbus.Conn, got nil")
+	}
+	if collection.Session == "" {
+		t.Fatalf("Expected a valid dbus.ObjectPath for session, got empty")
+	}
+	if collection.Path == "" {
+		t.Fatalf("Expected a valid dbus.ObjectPath for path, got empty")
+	}
+}
+
+// TestSecretCollection_Unlock tests the Unlock method of SecretCollection.
+func TestSecretCollection_Unlock(t *testing.T) {
+	if collection, err := Collection(testCollection); err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	} else {
+		if err := collection.Unlock(); err != nil {
+			t.Fatalf("Expected no error but got: %v", err)
+		}
+	}
+}
+
+// TestSecretCollection_Set tests the Set method of SecretCollection.
+func TestSecretCollection_Set(t *testing.T) {
+	if collection, err := Collection(testCollection); err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	} else {
+		if err := collection.Unlock(); err != nil {
+			t.Fatalf("Expected no error but got: %v", err)
+		}
+		if err := collection.Set(testApplication, testLabel, []byte(testData)); err != nil {
+			t.Fatalf("Expected no error but got: %v", err)
+		}
+	}
+}
+
+// TestSecretCollection_Get tests the Get method of SecretCollection.
+func TestSecretCollection_Get(t *testing.T) {
+	if collection, err := Collection(testCollection); err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	} else {
+		if err := collection.Unlock(); err != nil {
+			t.Fatalf("Expected no error but got: %v", err)
+		}
+		if item, err := collection.Get(testApplication, testLabel); err != nil {
+			t.Fatalf("Expected no error but got: %v", err)
+		} else {
+			t.Log(string(item))
+		}
+	}
+}


### PR DESCRIPTION
---
name: Pull request
about: If you have a pull request to fix a bug or add a feature
---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] You have read the contributing guide
- [x] Tests for the changes have been added
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

Insufficient level of abstraction in dbus_secrets to make the get and set commands maintainable

## What is the new behavior?

- An intermediate layer that offers a simpler interface to the Cobra layer
- Offers more helpful error messages
- 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

**If yes, please describe...**

## Other relevant information

Next, The Cobra layer will be adapted to use this then the original logic will be removed.